### PR TITLE
Fix --force causing an error during validation

### DIFF
--- a/ngctl
+++ b/ngctl
@@ -2326,7 +2326,8 @@ if [ "$ng_mode" != "query" ] && [ "$ng_mode" != "rmdown" ] && [ "$ng_mode" != "u
                                     printf "$back"
                                     out info "OK: Can't validate when scheduling ALL checks on host(s)\n"
                                 elif [ $flg_force -eq 1 ]; then
-                                    # Don't validate when using --force
+                                    # --force can be used when specifying a date/time so validation
+                                    # of next check time doesn't make sense
                                     flg_command_success=1
                                     datefunc unix $lql_post_result
                                     printf "$back"

--- a/ngctl
+++ b/ngctl
@@ -2325,6 +2325,12 @@ if [ "$ng_mode" != "query" ] && [ "$ng_mode" != "rmdown" ] && [ "$ng_mode" != "u
                                     flg_command_success=1
                                     printf "$back"
                                     out info "OK: Can't validate when scheduling ALL checks on host(s)\n"
+                                elif [ $flg_force -eq 1 ]; then
+                                    # Don't validate when using --force
+                                    flg_command_success=1
+                                    datefunc unix $lql_post_result
+                                    printf "$back"
+                                    out info "OK: Next check time is $func_time\n"
                                 else
                                     # You would think that -gt would make more sense here. race But condition.
                                     if [ $ng_next_check -ne $lql_post_result ]; then


### PR DESCRIPTION
Fixes error when using --force unless --all was also specified
$ng_next_check isn't defined when --force is specified, causing an error when validating new check time is sooner than existing check time.